### PR TITLE
Adding width/height convenience properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Minification filter. Used to set/get `gl.TEXTURE_MIN_FILTER`. Defaults to gl.NEA
 #### `tex.mipSamples`
 The number of anisotropic filtering samples to use.  This requires `EXT_texture_filter_anisotropic` to have any effect.  High values will improve mipmap quality, but decrease performance.
 
+#### `tex.width`
+Convenience getter/setter for `tex.shape[1]`
+
+#### `tex.height`
+Convenience getter/setter for `tex.shape[0]`
+
 ## Internals
 
 #### `tex.gl`
@@ -174,7 +180,6 @@ The internal format of the texture.
 
 #### `tex.type`
 The internal data type of the texture.
-
 
 # Credits
 (c) 2013 Mikola Lysenko. MIT License

--- a/texture.js
+++ b/texture.js
@@ -49,6 +49,24 @@ function Texture2D(gl, handle, width, height, format, type) {
   this._anisoSamples = 1
 }
 
+Object.defineProperty(Texture2D.prototype, "width", {
+  get: function() {
+    return this.shape[1]
+  },
+  set: function(v) {
+    this.shape[1] = v;
+  }
+})
+
+Object.defineProperty(Texture2D.prototype, "height", {
+  get: function() {
+    return this.shape[0]
+  },
+  set: function(v) {
+    this.shape[0] = v;
+  }
+})
+
 Object.defineProperty(Texture2D.prototype, "minFilter", {
   get: function() {
     return this._minFilter


### PR DESCRIPTION
IMO `tex.shape[1]` is a bit tedious and counter-intuitive, and width/height properties are worth adding. Not sure about setters, since it doesn't actually change the GPU texture, so maybe I could just take those out?

I'm starting to pull kami modules out of core, and everything is playing pretty nicely with gl-texture2d so far. This PR will allow the kami batcher to fall back to the texture's dimensions when the user doesn't specify it explicitly, see here:  
https://github.com/mattdesl/kami-batch/blob/master/examples/modules-gl.js