### PR TITLE
Read correct type argument

### DIFF
--- a/texture.js
+++ b/texture.js
@@ -538,7 +538,7 @@ function createTexture2D(gl) {
     return createTextureShape(gl, arguments[1], arguments[2], arguments[3]||gl.RGBA, arguments[4]||gl.UNSIGNED_BYTE)
   }
   if(Array.isArray(arguments[1])) {
-    return createTextureShape(gl, arguments[1][0]|0, arguments[1][1]|0, arguments[2]||gl.RGBA, arguments[4]||gl.UNSIGNED_BYTE)
+    return createTextureShape(gl, arguments[1][0]|0, arguments[1][1]|0, arguments[2]||gl.RGBA, arguments[3]||gl.UNSIGNED_BYTE)
   }
   if(typeof arguments[1] === 'object') {
     var obj = arguments[1]


### PR DESCRIPTION
```
0: gl
1: [height, width]
2: format
3: type
```
